### PR TITLE
Troubleshoot docker compose commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  ebpf_exporter:
+    # Use the prebuilt image that already includes examples
+    image: ghcr.io/cloudflare/ebpf_exporter:latest
+    privileged: true
+    ports:
+      - "9435:9435"
+    command:
+      - --config.dir=examples
+      - --config.names=timers
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+    # If you prefer to build locally with examples baked in, uncomment:
+    # build:
+    #   context: .
+    #   target: ebpf_exporter_with_examples
+
+    # If you want to use the locally checked-out examples (instead of bundled), uncomment:
+    # volumes:
+    #   - ./examples:/examples:ro
+    #   - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+    # On systems with AppArmor/SELinux that block BPF, you may need to uncomment:
+    # security_opt:
+    #   - apparmor:unconfined
+    #   - label:disable


### PR DESCRIPTION
Add `docker-compose.yml` to enable easy local setup and execution of `ebpf_exporter`.

The existing `README.md` commands for Docker Compose were reported as non-functional. This PR provides a working `docker-compose.yml` that uses a pre-built image and includes necessary configurations to get the service running quickly.

---
<a href="https://cursor.com/background-agent?bcId=bc-d22b651b-b423-4646-b072-a20dcb4d0c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d22b651b-b423-4646-b072-a20dcb4d0c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

